### PR TITLE
Allow optional props in timeline component

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@the-deep/reporting-module-components",
-    "version": "1.1.0-beta.3",
+    "version": "1.1.0-beta.4",
     "description": "React library for Reporting Module",
     "files": [
         "/build"

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@the-deep/reporting-module-components",
-    "version": "1.1.0-beta.2",
+    "version": "1.1.0-beta.3",
     "description": "React library for Reporting Module",
     "files": [
         "/build"

--- a/lib/src/components/Timeline/index.tsx
+++ b/lib/src/components/Timeline/index.tsx
@@ -9,11 +9,11 @@ import styles from './styles.module.css';
 
 interface TimelineData {
     date: string;
-    category: string;
     title: string;
-    details: string;
-    source: string;
-    link: string;
+    category?: string | undefined;
+    details?: string | undefined;
+    source?: string | undefined;
+    link?: string | undefined;
 }
 
 const timelineOptions = {

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -12,7 +12,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "@the-deep/reporting-module-components": "^1.1.0-beta.1",
+    "@the-deep/reporting-module-components": "^1.1.0-beta.3",
     "@types/d3": "^7.4.0",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.18.29",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -12,7 +12,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "@the-deep/reporting-module-components": "^1.1.0-beta.3",
+    "@the-deep/reporting-module-components": "^1.1.0-beta.4",
     "@types/d3": "^7.4.0",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.18.29",


### PR DESCRIPTION
## Changes

- Allow optional props in Timeline Component

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
